### PR TITLE
Typo on MIXPANEL_HOST key

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
     ```
 3. Add the MixPanel Host domain only if you need to change your MixPanel host from the default:
     ```env
-    MIXPANEL_TOKEN=xxxxxxxxxxxxxxxxxxxxxx
+    MIXPANEL_HOST=xxxxxxxxxxxxxxxxxxxxxx
     ```
 
 ## Configuration


### PR DESCRIPTION
Error designating the correct .env variable name bound to the configuration key.